### PR TITLE
Minor updates to match version in Blazor

### DIFF
--- a/DebugStore.cs
+++ b/DebugStore.cs
@@ -8,7 +8,7 @@ using Newtonsoft.Json.Linq;
 using System.Net.Http;
 
 namespace WsProxy {
-	public class BreakPointRequest {
+	internal class BreakPointRequest {
 		public string Assembly { get; private set; }
 		public string File { get; private set; }
 		public int Line { get; private set; }
@@ -42,7 +42,7 @@ namespace WsProxy {
 	}
 
 
-	public class VarInfo {
+	internal class VarInfo {
 		public VarInfo (VariableDebugInformation v)
 		{
 			this.Name = v.Name;
@@ -65,7 +65,7 @@ namespace WsProxy {
 	}
 
 
-	public class CliLocation {
+	internal class CliLocation {
 
 		private MethodInfo method;
 		private int offset;
@@ -81,7 +81,7 @@ namespace WsProxy {
 	}
 
 
-	public class SourceLocation {
+	internal class SourceLocation {
 		SourceId id;
 		int line;
 		int column;
@@ -137,7 +137,7 @@ namespace WsProxy {
 
 	}
 
-	public class SourceId {
+	internal class SourceId {
 		readonly int assembly, document;
 
 		public int Assembly => assembly;
@@ -196,7 +196,7 @@ namespace WsProxy {
 		}
 	}
 
-	public class MethodInfo {
+	internal class MethodInfo {
 		AssemblyInfo assembly;
 		internal MethodDefinition methodDef;
 		SourceFile source;
@@ -257,7 +257,7 @@ namespace WsProxy {
 	}
 
 
-	public class AssemblyInfo {
+	internal class AssemblyInfo {
 		static int next_id;
 		ModuleDefinition image;
 		readonly int id;
@@ -343,7 +343,7 @@ namespace WsProxy {
 
 	}
 
-	public class SourceFile {
+	internal class SourceFile {
 		HashSet<MethodInfo> methods;
 		AssemblyInfo assembly;
 		int id;
@@ -370,7 +370,7 @@ namespace WsProxy {
 		public IEnumerable<MethodInfo> Methods => this.methods;
 	}
 
-	public class DebugStore {
+	internal class DebugStore {
 		List<AssemblyInfo> assemblies = new List<AssemblyInfo> ();
 
 		public DebugStore (string[] loaded_files)

--- a/MonoProxy.cs
+++ b/MonoProxy.cs
@@ -12,7 +12,7 @@ using System.Collections.Generic;
 
 namespace WsProxy {
 
-	public class MonoCommands {
+	internal class MonoCommands {
 		public const string GET_CALL_STACK = "MONO.mono_wasm_get_call_stack()";
 		public const string IS_RUNTIME_READY_VAR = "MONO.mono_wasm_runtime_is_ready";
 		public const string START_SINGLE_STEPPING = "MONO.mono_wasm_start_single_stepping({0})";
@@ -22,7 +22,7 @@ namespace WsProxy {
 		public const string CLEAR_ALL_BREAKPOINTS = "MONO.mono_wasm_clear_all_breakpoints()";
 	}
 
-	public class MonoConstants {
+	internal class MonoConstants {
 		public const string RUNTIME_IS_READY = "mono_wasm_runtime_ready";
 	}
 	class Frame {
@@ -65,7 +65,7 @@ namespace WsProxy {
 		Over
 	}
 
-	public class MonoProxy : WsProxy {
+	internal class MonoProxy : WsProxy {
 		DebugStore store;
 		List<Breakpoint> breakpoints = new List<Breakpoint> ();
 		List<Frame> current_callstack;

--- a/MonoProxy.cs
+++ b/MonoProxy.cs
@@ -265,6 +265,15 @@ namespace WsProxy {
 						var method = asm.GetMethodByToken (method_token);
 						var location = method.GetLocationByIl (il_pos);
 
+						// When hitting a breakpoint on the "IncrementCount" method in the standard
+						// Blazor project template, one of the stack frames is inside mscorlib.dll
+						// and we get location==null for it. It will trigger a NullReferenceException
+						// if we don't skip over that stack frame.
+						if (location == null)
+						{
+							continue;
+						}
+
 						Info ($"frame il offset: {il_pos} method token: {method_token} assembly name: {assembly_name}");
 						Info ($"\tmethod {method.Name} location: {location}");
 						frames.Add (new Frame (method, location, frame_id));
@@ -403,7 +412,11 @@ namespace WsProxy {
 			var values = res.Value? ["result"]? ["value"]?.Values<JObject> ().ToArray ();
 
 			var var_list = new List<JObject> ();
-			for (int i = 0; i < vars.Length; ++i) {
+
+			// Trying to inspect the stack frame for DotNetDispatcher::InvokeSynchronously
+			// results in a "Memory access out of bounds", causing 'values' to be null,
+			// so skip returning variable values in that case.
+			for (int i = 0; values != null && i < vars.Length; ++i) {
 				var_list.Add (JObject.FromObject (new {
 					name = vars [i].Name,
 					value = values [i] ["value"]

--- a/Startup.cs
+++ b/Startup.cs
@@ -12,7 +12,7 @@ using System.Text;
 namespace WsProxy
 {
 
-	public class Startup {
+	internal class Startup {
 		// This method gets called by the runtime. Use this method to add services to the container.
 		// For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
 		public void ConfigureServices (IServiceCollection services)

--- a/WsProxy.cs
+++ b/WsProxy.cs
@@ -12,7 +12,7 @@ using System.Collections.Generic;
 
 namespace WsProxy {
 
-	public struct Result {
+	internal struct Result {
 		public JObject Value { get; private set; }
 		public JObject Error { get; private set; }
 
@@ -96,7 +96,7 @@ namespace WsProxy {
 		}
 	}
 
-	public class WsProxy {
+	internal class WsProxy {
 		TaskCompletionSource<bool> side_exception = new TaskCompletionSource<bool> ();
 		List<(int, TaskCompletionSource<Result>)> pending_cmds = new List<(int, TaskCompletionSource<Result>)> ();
 		ClientWebSocket browser;


### PR DESCRIPTION
This is all looking great, @kumpera!

Two tweaks in this PR:

 * Marked types as `internal`. I know you didn't have much reason to do that in this PR originally, but for as long as we are copying these sources into Blazor, we need them `internal` there to avoid exposing unwanted APIs and because anything `public` needs full XML docs otherwise our build process will reject it. Hopefully there's no drawback to you having them `internal` in this repo too. If you decide you don't want to do this that's fine, we'll just have to keep changing them all to `internal` whenever we pull updates into Blazor.
 * Patches for two cases where we encountered crashes. Maybe there are better fixes; these are just stopgap measures until/unless you have other ideas about how to handle it.